### PR TITLE
[improve] Fix Documentation link and markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Airflow 中文文档
 
-![](img/logo.png)
+![Airflow](img/logo.png)
 
-> 原文：[Apache Airflow Documentation](https://airflow.apache.org/)
-> 
+> 原文：[Apache Airflow Documentation](https://airflow.readthedocs.io/en/latest/project.html)
+>
 > 协议：[CC BY-NC-SA 4.0](http://creativecommons.org/licenses/by-nc-sa/4.0/)
-> 
+>
 > 欢迎任何人参与和完善：一个人可以走的很快，但是一群人却可以走的更远。
 
 * [在线阅读](https://airflow.apachecn.org)
@@ -24,4 +24,4 @@
 
 ## 赞助我们
 
-![](https://www.apachecn.org/img/about/donate.jpg)
+![Donate](https://www.apachecn.org/img/about/donate.jpg)


### PR DESCRIPTION
* Links latest link to Documentation
* Remove unnecessary space
* Add title to picture syntax in markdown