### PR TITLE
26

### DIFF
--- a/zh/26.md
+++ b/zh/26.md
@@ -1,99 +1,98 @@
 # 时区
 
-默认情况下启用对时区的支持。 Airflow在内部和数据库中以UTC格式存储日期时间信息。 它允许您使用时区相关的计划运行DAG。 目前，Airflow不会将其转换为用户界面中的最终用户时区。 它始终以UTC显示。 此外，操作符中使用的模板也不会被转换。 时区信息是暴露出来的，由DAG的作者负责。
+> 贡献者：[@morefreeze](https://github.com/morefreeze)
 
-如果您的用户居住在多个时区，并且您希望根据每个用户的挂钟显示日期时间信息，这将非常方便。
+默认情况下启用对时区的支持。 Airflow 在内部处理和数据库中以 UTC 格式存储日期时间信息。 这样您就可以在调度中执行带有时区的 DAG。 目前，Airflow 不支持在 Web UI 中显示最终用户时区，它始终以UTC显示。 此外，`Operator`中使用的模板也不会被转换。 时区信息取决于 DAG 作者如何使用它。
 
-即使您只在一个时区运行Airflow，在数据库中以UTC格式存储数据仍然是一种很好的做法（在Airflow成为时区之前也是如此，这也是建议的甚至是必需的设置）。 主要原因是夏令时（DST）。 许多国家都有DST系统，其中时钟在春季向前移动，在秋季向后移动。 如果您在当地工作，那么当转换发生时，您可能每年会遇到两次错误。 （钟摆和pytz文档更详细地讨论了这些问题。）这对于简单的DAG可能无关紧要，但如果您处于金融服务中，那么这是一个问题，在这些金融服务中您可以满足最后期限。
+如果您的用户居住在多个时区，并且您希望根据每个用户的挂钟(wall clock)显示日期时间信息，这将非常方便。
 
-时区在&lt;cite&gt;airflow.cfg中&lt;/cite&gt;设置。 默认情况下，它设置为utc，但您将其更改为使用系统设置或任意IANA时区，例如&lt;cite&gt;Europe / Amsterdam&lt;/cite&gt; 。 它取决于&lt;cite&gt;钟摆&lt;/cite&gt; ，它比&lt;cite&gt;pytz&lt;/cite&gt;更准确。 安装Airflow时会安装Pendulum。
+即使您只在一个时区运行 Airflow，在数据库中以 UTC 格式存储数据仍然是一种很好的做法（在 Airflow 关心时区问题之前也是如此，这也是推荐的甚至是必需的设置）。 主要原因是夏令时（DST）。 许多国家都有 DST 系统，其中时间在春季向前移动，在秋季向后移动。 如果您在当地工作，那么当发生转换时，您可能每年会遇到两次错误。 （pendulum 和 pytz 文档更详细地讨论了这些问题。）这可能并不影响简单的 DAG，但如果您涉及金融服务中，这可能就变成灾难。
 
-请注意，Web UI目前仅以UTC格式运行。
+时区在`airflow.cfg`中设置。 默认情况下，它设置为 utc，您可以将其更改为使用系统设置或任意 IANA 时区，例如`Europe/Amsterdam` (阿姆斯特丹)。 安装 Airflow 时会安装 Pendulum，它比 pytz 更精确，也会让您更容易处理时区问题。
+
+请注意，**Web UI 目前仅以 UTC 格式运行**。
 
 ## 概念
 
-### 天真并了解日期时间对象
+### 了解 datetime 时区敏感对象
 
-Python的datetime.datetime对象具有tzinfo属性，可用于存储时区信息，表示为datetime.tzinfo的子类的实例。 设置此属性并描述偏移量时，可以识别日期时间对象。 否则，这是天真的。
+Python 的 datetime.datetime 对象的时区信息存储在 tzinfo 属性中，它是 datetime.tzinfo 类的对象。 设置 tzinfo 会使 datetime 对象变为时区敏感，否则就是不敏感。
 
-您可以使用timezone.is_aware（）和timezone.is_naive（）来确定日期时间是否知晓或天真。
+您可以使用`timezone.is_aware()`和`timezone.is_naive()`来确定 datetime 是否时区敏感。
 
-因为Airflow使用时区感知日期时间对象。 如果您的代码创建了datetime对象，那么他们也需要注意。
+因为 Airflow 使用时区敏感 datetime 对象，所以您创建 datetime 对象时也应该考虑时区问题。
 
 ```py
- from airflow.utils import timezone
+from airflow.utils import timezone
 
-now = timezone . utcnow ()
-a_date = timezone . datetime ( 2017 , 1 , 1 )
+now = timezone.utcnow()
+a_date = timezone.datetime(2017,1,1)
 
 ```
 
-### 解释天真的日期时间对象
+### 解释原生 datetime 对象
 
-尽管Airflow完全可以识别时区，但它仍然可以在DAG定义中为&lt;cite&gt;start_dates&lt;/cite&gt;和&lt;cite&gt;end_dates&lt;/cite&gt;接受天真的日期时间对象。 这主要是为了保持向后兼容性。 如果遇到天真的&lt;cite&gt;start_date&lt;/cite&gt;或&lt;cite&gt;end_date，&lt;/cite&gt;则应用默认时区。 它以这样的方式应用，即假定天真日期时间已经在默认时区。 换句话说，如果您有&lt;cite&gt;欧洲/阿姆斯特丹&lt;/cite&gt;的默认时区设置并创建&lt;cite&gt;日期时间（2017,1,1）&lt;/cite&gt;的天真日期时间&lt;cite&gt;start_date&lt;/cite&gt; ，则假定它是2017年1月1日阿姆斯特丹时间的&lt;cite&gt;start_date&lt;/cite&gt; 。
+尽管 Airflow 现在是时区敏感的，但为了向后兼容，它仍然允许在 DAG 定义中使用原生 datetime 为`start_dates`和`end_dates`赋值。 如果遇到使用原生 datetime 的`start_date`或`end_date`则使用默认时区。 换句话说，如果您设置了默认时区为`Europe/Amsterdam`，那么对于`start_date = datetime(2017,1,1)`，则认定它是2017年1月1日的 Amesterdam 时间。
 
 ```py
- default_args = dict (
-    start_date = datetime ( 2016 , 1 , 1 ),
+ default_args = dict(
+    start_date = datetime(2016,1,1),
     owner = 'Airflow'
 )
 
-dag = DAG ( 'my_dag' , default_args = default_args )
-op = DummyOperator ( task_id = 'dummy' , dag = dag )
-print ( op . owner ) # Airflow
+dag = DAG ('my_dag',default_args=default_args )
+op = DummyOperator(task_id='dummy',dag=dag)
+print(op.owner) # Airflow
 
 ```
 
-不幸的是，在DST转换期间，某些日期时间不存在或不明确。 在这种情况下，钟摆会引发异常。 这就是为什么在启用时区支持时应始终创建有意识的日期时间对象的原因。
+不幸的是，在 DST 转换期间，某些时间不存在或有二义性。 在这种情况下，pendulum 会抛出异常。 这就是为什么在启用时区支持时应始终创建时区敏感的 datetime 对象。
 
-实际上，这很少是一个问题。 Airflow可以让您了解模型和DAG中的日期时间对象，并且通常，新的日期时间对象是通过timedelta算法从现有对象创建的。 通常在应用程序代码中创建的唯一日期时间是当前时间，timezone.utcnow（）自动执行正确的操作。
+实际上，这个问题几乎不会发生。 在 model 或 DAG中，Airflow 总是返回给您的是时区敏感的 datetime 对象，通常新的 datetime 对象是通过现有对象和 timedelta 计算而来的。 唯一经常创建并且可能出问题的是当前时间，用`timezone.utcnow()`会避免这些麻烦。
 
 ### 默认时区
 
-默认时区是由&lt;cite&gt;[core]&lt;/cite&gt;下的&lt;cite&gt;default_timezone&lt;/cite&gt;设置定义的时区。 如果您刚刚安装了Airflow，它将被设置为&lt;cite&gt;utc&lt;/cite&gt; ，这是推荐的。 您还可以将其设置为&lt;cite&gt;系统&lt;/cite&gt;或IANA时区（例如“欧洲/阿姆斯特丹”）。 DAG也在Airflow工作人员上进行评估，因此确保所有Airflow节点上的此设置相同非常重要。
+默认时区是在`airflow.cfg`中的`[core]`下的`default_timezone`定义的。 如果您刚刚安装了Airflow，它推荐您设置为 utc。 您还可以将其设置为 system 或 IANA 时区（例如`Europe/Amsterdam`）。 DAG 也会 Airflow 的 worker 上进行计算，因此确保所有 Airflow 节点上的此设置相同。
 
 ```py
- [ core ]
+[core]
 default_timezone = utc
-
 ```
 
-## 时区感知DAG
+## 时区敏感 DAG
 
-创建时区感知DAG非常简单。 只需确保提供时区感知&lt;cite&gt;start_date&lt;/cite&gt; 。 建议使用&lt;cite&gt;摆锤&lt;/cite&gt; ，但也可以使用&lt;cite&gt;pytz&lt;/cite&gt; （手动安装）。
+只需设置`start_date`为时区敏感的 datetime，就创建了时区敏感的 DAG。 建议使用 pendulum，但也可以使用 pytz（手动安装）。
 
 ```py
- import pendulum
+import pendulum
 
-local_tz = pendulum . timezone ( "Europe/Amsterdam" )
+local_tz = pendulum.timezone("Europe/Amsterdam")
 
 default_args = dict (
-    start_date = datetime ( 2016 , 1 , 1 , tzinfo = local_tz ),
+    start_date = datetime(2016, 1, 1, tzinfo=local_tz),
     owner = 'Airflow'
 )
 
-dag = DAG ( 'my_tz_dag' , default_args = default_args )
-op = DummyOperator ( task_id = 'dummy' , dag = dag )
-print ( dag . timezone ) # <Timezone [Europe/Amsterdam]>
-
+dag = DAG('my_tz_dag', default_args=default_args)
+op = DummyOperator(task_id='dummy',dag=dag)
+print(dag.timezone) # <Timezone [Europe/Amsterdam]>
 ```
 
 ### 模板
 
-Airflow在模板中返回时区感知日期时间，但不会将它们转换为本地时间，因此它们保持UTC。 由DAG来处理这个问题。
+Airflow 在模板中返回时区敏感的 datetime，但不会将它们转换为本地时间，因此它们仍然是 UTC 时区。 由DAG来处理转换。
 
 ```py
- import pendulum
+import pendulum
 
-local_tz = pendulum . timezone ( "Europe/Amsterdam" )
-local_tz . convert ( execution_date )
-
+local_tz = pendulum.timezone("Europe/Amsterdam")
+local_tz.convert(execution_date)
 ```
 
-### Cron安排
+### Cron 安排
 
-如果您设置了cron计划，Airflow会假定您始终希望在同一时间运行。 然后它将忽略日光节省时间。 因此，如果您有一个时间表，表示每天在格林威治标准时间08:00 + 1的间隔结束时运行，它将始终在08:00格林尼治标准时间+ 1的间隔结束时运行，无论日间节电时间是否到位。
+如果您设置了 crontab，Airflow 会假定您始终希望在同一时间运行。 然后它将忽略 DST。 因此，如果您有一个调度要在每天格林威治标准时间+1 的 08:00运行，它将始终在这个时间运行，**无论 DST 是否发生**。
 
 ### 时间增量
 
-对于具有时间增量的计划，Airflow假定您始终希望以指定的间隔运行。 因此，如果您指定timedelta（hours = 2），您将始终希望运行数小时。 在这种情况下，将考虑日光节省时间。
+对于具有时间增量的调度，Airflow 假定您始终希望以指定的间隔运行。 因此，如果您指定 `timedelta(hours=2)`，您将始终希望每两小时运行一次。 在这种情况下，将**考虑 DST**。

--- a/zh/26.md
+++ b/zh/26.md
@@ -10,13 +10,13 @@
 
 时区在`airflow.cfg`中设置。 默认情况下，它设置为 utc，您可以将其更改为使用系统设置或任意 IANA 时区，例如`Europe/Amsterdam` (阿姆斯特丹)。 安装 Airflow 时会安装 Pendulum，它比 pytz 更精确，也会让您更容易处理时区问题。
 
-请注意，**Web UI 目前仅以 UTC 格式运行**。
+请注意，**Web UI 目前仅显示 UTC 时间**。
 
 ## 概念
 
 ### 了解 datetime 时区敏感对象
 
-Python 的 datetime.datetime 对象的时区信息存储在 tzinfo 属性中，它是 datetime.tzinfo 类的对象。 设置 tzinfo 会使 datetime 对象变为时区敏感，否则就是不敏感。
+tzinfo 是 datetime.datetime 对象中表示时区信息的属性，它是 datetime.tzinfo 类的对象。 设置 tzinfo 会使 datetime 对象变为时区敏感，否则就是不敏感。
 
 您可以使用`timezone.is_aware()`和`timezone.is_naive()`来确定 datetime 是否时区敏感。
 
@@ -27,32 +27,31 @@ from airflow.utils import timezone
 
 now = timezone.utcnow()
 a_date = timezone.datetime(2017,1,1)
-
 ```
 
-### 解释原生 datetime 对象
+### 理解原生 datetime 对象
 
 尽管 Airflow 现在是时区敏感的，但为了向后兼容，它仍然允许在 DAG 定义中使用原生 datetime 为`start_dates`和`end_dates`赋值。 如果遇到使用原生 datetime 的`start_date`或`end_date`则使用默认时区。 换句话说，如果您设置了默认时区为`Europe/Amsterdam`，那么对于`start_date = datetime(2017,1,1)`，则认定它是2017年1月1日的 Amesterdam 时间。
 
 ```py
  default_args = dict(
-    start_date = datetime(2016,1,1),
+    start_date = datetime(2016, 1, 1),
     owner = 'Airflow'
 )
 
-dag = DAG ('my_dag',default_args=default_args )
-op = DummyOperator(task_id='dummy',dag=dag)
+dag = DAG ('my_dag', default_args=default_args)
+op = DummyOperator(task_id='dummy', dag=dag)
 print(op.owner) # Airflow
 
 ```
 
 不幸的是，在 DST 转换期间，某些时间不存在或有二义性。 在这种情况下，pendulum 会抛出异常。 这就是为什么在启用时区支持时应始终创建时区敏感的 datetime 对象。
 
-实际上，这个问题几乎不会发生。 在 model 或 DAG中，Airflow 总是返回给您的是时区敏感的 datetime 对象，通常新的 datetime 对象是通过现有对象和 timedelta 计算而来的。 唯一经常创建并且可能出问题的是当前时间，用`timezone.utcnow()`会避免这些麻烦。
+实际上，这个问题几乎不会发生。 在 model 或 DAG 中，Airflow 总是返回给您的是时区敏感的 datetime 对象，通常新的 datetime 对象是通过现有对象和 timedelta 计算而来的。 唯一经常创建并且可能出问题的是当前时间，用`timezone.utcnow()`会避免这些麻烦。
 
 ### 默认时区
 
-默认时区是在`airflow.cfg`中的`[core]`下的`default_timezone`定义的。 如果您刚刚安装了Airflow，它推荐您设置为 utc。 您还可以将其设置为 system 或 IANA 时区（例如`Europe/Amsterdam`）。 DAG 也会 Airflow 的 worker 上进行计算，因此确保所有 Airflow 节点上的此设置相同。
+默认时区是在`airflow.cfg`中的`[core]`下的`default_timezone`定义的。 如果您刚刚安装了Airflow，它推荐您设置为 utc。 您还可以将其设置为系统或 IANA 时区（例如`Europe/Amsterdam`）。 DAG 也会在 worker 上进行计算，因此确保所有 worker 节点上的此设置相同。
 
 ```py
 [core]
@@ -74,13 +73,13 @@ default_args = dict (
 )
 
 dag = DAG('my_tz_dag', default_args=default_args)
-op = DummyOperator(task_id='dummy',dag=dag)
+op = DummyOperator(task_id='dummy', dag=dag)
 print(dag.timezone) # <Timezone [Europe/Amsterdam]>
 ```
 
 ### 模板
 
-Airflow 在模板中返回时区敏感的 datetime，但不会将它们转换为本地时间，因此它们仍然是 UTC 时区。 由DAG来处理转换。
+Airflow 在模板中返回时区敏感的 datetime，但不会将它们转换为本地时间，因此它们仍然是 UTC 时区。 由 DAG 来处理转换。
 
 ```py
 import pendulum
@@ -91,8 +90,8 @@ local_tz.convert(execution_date)
 
 ### Cron 安排
 
-如果您设置了 crontab，Airflow 会假定您始终希望在同一时间运行。 然后它将忽略 DST。 因此，如果您有一个调度要在每天格林威治标准时间+1 的 08:00运行，它将始终在这个时间运行，**无论 DST 是否发生**。
+如果您设置了 crontab，Airflow 会假定您始终希望在同一时间运行。 然后它将忽略 DST。 比如，您有一个调度要在每天格林威治标准时间 +1 的 08:00运行，它将始终在这个时间运行，**无论 DST 是否发生**。
 
-### 时间增量
+### 时间增量调度
 
-对于具有时间增量的调度，Airflow 假定您始终希望以指定的间隔运行。 因此，如果您指定 `timedelta(hours=2)`，您将始终希望每两小时运行一次。 在这种情况下，将**考虑 DST**。
+对于具有时间增量的调度，Airflow 假定您始终希望以指定的间隔运行。 比如，您指定`timedelta(hours=2)`运行，它将始终每两小时运行一次。 在这种情况下，**将考虑 DST**。


### PR DESCRIPTION
有些地方为了通顺需要，没有完全按照原文翻译。

另外我发现最新的[1.10.2的文档关于 "Time zone aware DAGs"](https://airflow.apache.org/timezone.html#time-zone-aware-dags) 代码后面有一段新的，但我仍然按照/en/26.html 进行了翻译，这也是我提议可以放在read the doc上去的原因，随时保持更新，即使保持不了更新，也能知道我们翻译的是哪一版
@wizardforcel PTAL